### PR TITLE
expose ES6 module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/morbidick/lit-element-notify"
   },
   "main": "index.js",
+  "module": "index.js",
   "peerDependencies": {
     "lit-element": "^2.0.1",
     "lit-html": "^1.0.0"


### PR DESCRIPTION
With the main module specified in package.json, it is possible to pack this ES6 module with pika. It can then be imported as such:

```javascript
import { LitSync } from '../web_modules/@morbidick/lit-element-notify.js';
```