### PR TITLE
fix example code in comparison-table doc

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -70,7 +70,7 @@ Synchronizing a parent property with a childs property.
 ### PolymerElement*
 
 ```js
-html`<element value="{{myProperty}}></element>
+html`<element value="{{myProperty}}"></element>`
 ```
 
 ### Lit Element - upwards binding only


### PR DESCRIPTION
While reading the docs, I have noticed that open backticks and quotes have not been closed in example code of the comparison table doc.