### PR TITLE
call target.updated() manually when no setter is defined

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -28,7 +28,11 @@ export const LitSync = (baseElement) => class extends baseElement {
                 const notifyingEvent = eventName || eventNameForProperty(notifyingProperty);
 
                 notifyingElement.addEventListener(notifyingEvent, (e) => {
+                    const oldValue = this[property];
                     this[property] = e.detail.value;
+                    if (this.__lookupSetter__(property) === undefined) {
+                        this.updated(new Map([[property, oldValue]]));
+                    }
                 });
             }
         });


### PR DESCRIPTION
The sync directive does not always notify the receiving element. On some occasions, I have observed that `target[property] = value` remains without effect on the notified element. This changes lookup the getter and manually call the `updated(changedProperties)` with the current property.

@morbidick maybe you have an idea why this is necessary 🤷‍♂ 