### PR TITLE
Replace return by continue

### DIFF
--- a/notify.js
+++ b/notify.js
@@ -30,7 +30,7 @@ export const LitNotify = (baseElement) => class NotifyingElement extends baseEle
 
         for (const prop of changedProps.keys()) {
             const declaration = this.constructor._classProperties.get(prop)
-            if (!declaration || !declaration.notify) return;
+            if (!declaration || !declaration.notify) continue;
             const type = eventNameForProperty(prop, declaration)
             const value = this[prop]
             this.dispatchEvent(new CustomEvent(type, { detail: { value } }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@morbidick/lit-element-notify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morbidick/lit-element-notify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Small helpers for LitElement to dispatch change notifications and two-way binding",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Hi,

Between [v1.0.2...v1.1.0](https://github.com/morbidick/lit-element-notify/compare/v1.0.2...v1.1.0#diff-bd33361ada7e8d2d2fefd6aa1b7a6061R33), we observed a new bug where a property change was not notified. We pinpointed the bug at line 33, where the function returns if at least one properties doesn't need to be notify.

So we simply replaced `return` by `continue` to continue to the next property and the bug was fixed. :)

Thanks!